### PR TITLE
Make the configuration file be driven by command line arguments

### DIFF
--- a/maple_workflow.py
+++ b/maple_workflow.py
@@ -195,7 +195,6 @@ def infer_image(config: MPL_Config, input_img_name: str):
     sys.path.append(config.ROOT_DIR)
 
     # worker roots
-    worker_root = config.WORKER_ROOT
     worker_divided_img_root = config.DIVIDED_IMAGE_DIR
 
     # Create subfolder for each image
@@ -215,11 +214,9 @@ def infer_image(config: MPL_Config, input_img_name: str):
         print("directory deletion failed")
         pass
 
-    POLYGON_DIR = worker_root
 
     inference.inference_image(
         config,
-        POLYGON_DIR,
         worker_output_shp_subroot,
         file1,
         file2,

--- a/maple_workflow.py
+++ b/maple_workflow.py
@@ -43,6 +43,7 @@ def tile_image(config: MPL_Config, input_img_name: str):
 
     Parameters
     ----------
+    config : Contains static configuration information regarding the workflow.
     input_img_name : Name of the input image
     """
     sys.path.append(config.ROOT_DIR)
@@ -85,6 +86,7 @@ def cal_water_mask(config: MPL_Config, input_img_name: str):
     Uses gdal to transform the image into the required format.
     Parameters
     ----------
+    config : Contains static configuration information regarding the workflow.
     input_img_name : Name of the input image
     """
     image_file_name = (input_img_name).split(".tif")[0]
@@ -187,6 +189,7 @@ def infer_image(config: MPL_Config, input_img_name: str):
 
     Parameters
     ----------
+    config : Contains static configuration information regarding the workflow.
     input_img_name : Name of the input image file
     """
     sys.path.append(config.ROOT_DIR)
@@ -213,12 +216,10 @@ def infer_image(config: MPL_Config, input_img_name: str):
         pass
 
     POLYGON_DIR = worker_root
-    weights_path = config.WEIGHT_PATH
 
     inference.inference_image(
         config,
         POLYGON_DIR,
-        weights_path,
         worker_output_shp_subroot,
         file1,
         file2,
@@ -234,6 +235,7 @@ def stich_shapefile(config: MPL_Config, input_img_name: str):
 
     Parameters
     ----------
+    config : Contains static configuration information regarding the workflow.
     input_img_name : Name of the input image file
 
     Returns
@@ -271,7 +273,7 @@ def stich_shapefile(config: MPL_Config, input_img_name: str):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Extract IWPs from sateliate image scenes using MAPLE."
+        description="Extract IWPs from satellite image scenes using MAPLE."
     )
 
     # Optional Arguments

--- a/maple_workflow.py
+++ b/maple_workflow.py
@@ -36,7 +36,7 @@ WORKTAG = 1
 DIETAG = 0
 
 
-def tile_image(input_img_name):
+def tile_image(config: MPL_Config, input_img_name: str):
     """
     Tile the image into multiple pre-deifined sized parts so that the processing can be done on smaller parts due to
     processing limitations
@@ -45,14 +45,13 @@ def tile_image(input_img_name):
     ----------
     input_img_name : Name of the input image
     """
-    sys.path.append(MPL_Config.ROOT_DIR)
+    sys.path.append(config.ROOT_DIR)
 
-    crop_size = MPL_Config.CROP_SIZE
+    crop_size = config.CROP_SIZE
 
     # worker roots
-    worker_img_root = MPL_Config.INPUT_IMAGE_DIR
-    worker_divided_img_root = MPL_Config.DIVIDED_IMAGE_DIR
-
+    worker_img_root = config.INPUT_IMAGE_DIR
+    worker_divided_img_root = config.DIVIDED_IMAGE_DIR
     # input image path
     input_img_path = os.path.join(worker_img_root, input_img_name)
 
@@ -75,12 +74,12 @@ def tile_image(input_img_name):
     # Call divide image <mpl_divided_img_water> to put the water mask and also to tile and store the data
     # Multiple image overlaps are NOT taken into account in called code.
     #
-    divide.divide_image(input_img_path, crop_size, file1, file2)
+    divide.divide_image(config, input_img_path, crop_size, file1, file2)
 
     print("finished tiling")
 
 
-def cal_water_mask(input_img_name):
+def cal_water_mask(config: MPL_Config, input_img_name: str):
     """
     This will calculate the water mask to avoid (inference) processing of the masked areas with water
     Uses gdal to transform the image into the required format.
@@ -90,11 +89,9 @@ def cal_water_mask(input_img_name):
     """
     image_file_name = (input_img_name).split(".tif")[0]
 
-    worker_water_root = (
-        MPL_Config.WATER_MASK_DIR
-    )  # os.path.join(worker_root, "water_shp")
+    worker_water_root = config.WATER_MASK_DIR  # os.path.join(worker_root, "water_shp")
     temp_water_root = (
-        MPL_Config.TEMP_W_IMG_DIR
+        config.TEMP_W_IMG_DIR
     )  # os.path.join(worker_root, "temp_8bitmask")
 
     worker_water_subroot = os.path.join(worker_water_root, image_file_name)
@@ -124,7 +121,7 @@ def cal_water_mask(input_img_name):
     )
     nir_band = 3  # set number of NIR band
 
-    input_image = os.path.join(MPL_Config.INPUT_IMAGE_DIR, input_img_name)
+    input_image = os.path.join(config.INPUT_IMAGE_DIR, input_img_name)
 
     # %% Median and Otsu
     value = 5
@@ -184,7 +181,7 @@ def cal_water_mask(input_img_name):
     dst_ds = None
 
 
-def infer_image(input_img_name):
+def infer_image(config: MPL_Config, input_img_name: str):
     """
     Inference based on the trained model reperesented by the saved weights
 
@@ -192,11 +189,11 @@ def infer_image(input_img_name):
     ----------
     input_img_name : Name of the input image file
     """
-    sys.path.append(MPL_Config.ROOT_DIR)
+    sys.path.append(config.ROOT_DIR)
 
     # worker roots
-    worker_root = MPL_Config.WORKER_ROOT
-    worker_divided_img_root = MPL_Config.DIVIDED_IMAGE_DIR
+    worker_root = config.WORKER_ROOT
+    worker_divided_img_root = config.DIVIDED_IMAGE_DIR
 
     # Create subfolder for each image
     new_file_name = input_img_name.split(".tif")[0]
@@ -207,7 +204,7 @@ def infer_image(input_img_name):
     file1 = os.path.join(worker_divided_img_subroot, "image_data.h5")
     file2 = os.path.join(worker_divided_img_subroot, "image_param.h5")
 
-    worker_output_shp_root = MPL_Config.OUTPUT_SHP_DIR
+    worker_output_shp_root = config.OUTPUT_SHP_DIR
     worker_output_shp_subroot = os.path.join(worker_output_shp_root, new_file_name)
     try:
         shutil.rmtree(worker_output_shp_subroot)
@@ -216,9 +213,10 @@ def infer_image(input_img_name):
         pass
 
     POLYGON_DIR = worker_root
-    weights_path = MPL_Config.WEIGHT_PATH
+    weights_path = config.WEIGHT_PATH
 
     inference.inference_image(
+        config,
         POLYGON_DIR,
         weights_path,
         worker_output_shp_subroot,
@@ -230,7 +228,7 @@ def infer_image(input_img_name):
     print("done")
 
 
-def stich_shapefile(input_img_name):
+def stich_shapefile(config: MPL_Config, input_img_name: str):
     """
     Put (stich) the image tiles back to the original
 
@@ -242,10 +240,10 @@ def stich_shapefile(input_img_name):
     -------
 
     """
-    sys.path.append(MPL_Config.ROOT_DIR)
+    sys.path.append(config.ROOT_DIR)
 
-    worker_finaloutput_root = MPL_Config.FINAL_SHP_DIR
-    worker_output_shp_root = MPL_Config.OUTPUT_SHP_DIR
+    worker_finaloutput_root = config.FINAL_SHP_DIR
+    worker_output_shp_root = config.OUTPUT_SHP_DIR
 
     # Create subfolder for each image within the worker img root
     new_file_name = input_img_name.split(".tif")[0]
@@ -261,6 +259,7 @@ def stich_shapefile(input_img_name):
     os.mkdir(worker_finaloutput_subroot)
 
     stich.stitch_shapefile(
+        config,
         worker_output_shp_subroot,
         worker_finaloutput_subroot,
         new_file_name,
@@ -284,23 +283,52 @@ if __name__ == "__main__":
         help="Image name",
     )
 
+    parser.add_argument(
+        "--root_dir",
+        required=False,
+        default="",
+        help="The directory path from where the workflow is running. If none is "
+        "provided, the current working directory will be used by the workflow.",
+    )
+
+    parser.add_argument(
+        "--weight_file",
+        required=False,
+        default="hyp_best_train_weights_final.h5",
+        help="The file path to where the model weights can be found. Should be "
+        "relative to the root directory.",
+    )
+
+    parser.add_argument(
+        "--gpus_per_core",
+        required=False,
+        default=1,
+        help="Number of GPUs available per core. Used to determine how many "
+        "inference processes to spin up. Set this to 0 if you want to run the "
+        "workflow on a CPU.",
+        type=int
+    )
+
     args = parser.parse_args()
 
     image_name = args.image
+    config = MPL_Config(
+        args.root_dir, args.weight_file, num_gpus_per_core=args.gpus_per_core
+    )
 
     print("1.start caculating wartermask")
-    cal_water_mask(image_name)
+    cal_water_mask(config, image_name)
     print("2. start tiling image")
-    tile_image(image_name)
+    tile_image(config, image_name)
     print("3. start inferencing")
-    infer_image(image_name)
+    infer_image(config, image_name)
     print("4. start stiching")
-    stich_shapefile(image_name)
-    process.process_shapefile(image_name)
+    stich_shapefile(config, image_name)
+    process.process_shapefile(config, image_name)
     print("5. start cleaning")
     inf_clean.clean_inference_shapes(
-        MPL_Config.CLEAN_DATA_DIR,
-        MPL_Config.PROJECTED_SHP_DIR,
+        config.CLEAN_DATA_DIR,
+        config.PROJECTED_SHP_DIR,
         "./data/input_bound/sample2_out_boundry.shp",
     )
 

--- a/mpl_clean_inference.py
+++ b/mpl_clean_inference.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-#env maple
+# env maple
 """
 MAPLE Workflow
 (5) Code base to clean the inferences from known artifacts.
@@ -19,13 +19,16 @@ Project: Permafrost Discovery Gateway: Mapping Application for Arctic Permafrost
 PI      : Chandi Witharana
 Author  : Amal Shehan Perera
 """
+
+from mpl_config import MPL_Config
 from osgeo import ogr, osr
 import os
 import time
 import glob
 
+
 def listdirpaths(folder):
-    """ List the file paths in a folder/directory so that they can be read
+    """List the file paths in a folder/directory so that they can be read
     Returns:
         list of file paths
     Arguments:
@@ -33,18 +36,23 @@ def listdirpaths(folder):
         Output
     """
     return [
-        d for d in (os.path.join(folder, d1) for d1 in os.listdir(folder))
+        d
+        for d in (os.path.join(folder, d1) for d1 in os.listdir(folder))
         if os.path.isdir(d)
     ]
 
+
 ######################## GLOBAL settings ################################################
 # Reporting verbosity to find out deletion of polygons for testing
-VERBOSE_granularity=0 # output print frequency for deleting loops 0 will have no outputs 1=all 10=every 10
+VERBOSE_granularity = 0  # output print frequency for deleting loops 0 will have no outputs 1=all 10=every 10
+
+
 #########################################################################################
-def clean_inference_shapes(clean_data_dir="./data/cln_data",
-                           input_data_dir="./data/projected_shp",
-                           input_data_boundary_file_path="./data/input_bound/sample2_out_boundry.shp",
-                           ):
+def clean_inference_shapes(
+    clean_data_dir="./data/cln_data",
+    input_data_dir="./data/projected_shp",
+    input_data_boundary_file_path="./data/input_bound/sample2_out_boundry.shp",
+):
     """Clean Known false positives (mis-classified) Polygons, based on known ground truth (rivers,lakes,buildings,etc
     Parameters:
         clean_data_dir: Location where you have the cleaning data ground truth to be used for cleaning
@@ -52,13 +60,13 @@ def clean_inference_shapes(clean_data_dir="./data/cln_data",
         input_data_boundary_file_path: Boundary/Envelope of the input data files if available to reduce compute.
         ToDo:Refactor this function to show the higher level abstract functionality
     """
-    st=time.time()
+    st = time.time()
     # LOAD the cleaning data files
     ogr.UseExceptions()  # Enable gdal:ogr errors to be captured/shown so that we know when things fail!
-                         # Note: No error handling in gdal
-    try: #LOAD cleaning data
-        drv = ogr.GetDriverByName('ESRI Shapefile')
-        try: #GET the source/input file projected coordinate system to transfer the cleaning data coordinates
+    # Note: No error handling in gdal
+    try:  # LOAD cleaning data
+        drv = ogr.GetDriverByName("ESRI Shapefile")
+        try:  # GET the source/input file projected coordinate system to transfer the cleaning data coordinates
             input_data_fps = listdirpaths(input_data_dir)
             inDataFile = drv.Open(input_data_fps[0])
             inDataLyr = inDataFile.GetLayer()
@@ -66,34 +74,42 @@ def clean_inference_shapes(clean_data_dir="./data/cln_data",
             # loading projection
             sr = osr.SpatialReference(str(inSpatialRef))
             srid = sr.GetAuthorityCode(None)
-            print("Input Data SRID:",srid)
+            print("Input Data SRID:", srid)
 
             print("Geo Ref for input data for transformation of cleaning data obtained")
         except:
-            print("Unable to get Geo Ref for input data for transfomation of cleaning data")
+            print(
+                "Unable to get Geo Ref for input data for transfomation of cleaning data"
+            )
 
-        clean_data_fps = [(clean_data_dir+"/"+f_nm) for f_nm in os.listdir(clean_data_dir) if f_nm.endswith('.shp')]
+        clean_data_fps = [
+            (clean_data_dir + "/" + f_nm)
+            for f_nm in os.listdir(clean_data_dir)
+            if f_nm.endswith(".shp")
+        ]
 
         print("*********************************************")
         print("List of cleaning data files selected to LOAD:")
-        print(*clean_data_fps,sep="\n")
+        print(*clean_data_fps, sep="\n")
         try:
             all_geoms_union = ogr.Geometry(ogr.wkbMultiPolygon)
             for fp in clean_data_fps:
                 # Open cleaning data files:layer
-                print("Loading Cleaning Data FILE:\n",fp)
+                print("Loading Cleaning Data FILE:\n", fp)
                 try:
-                    dc = drv.Open(fp,True)  # True allowed to edit if there are errors
+                    dc = drv.Open(fp, True)  # True allowed to edit if there are errors
                 except:
                     print("Unable to open cleaning Data:", fp)
                 try:
                     c_lyr = dc.GetLayer()
                 except:
                     print("Unable to get Layer in cleaning Data:", fp)
-                if (c_lyr.GetFeatureCount()>1):
-                    print("Warning: More than 1 feature in cleaning shapefile only first taken, dissolve data and use")
-                try: #Try to fix geom errors in cleaning data before reaging for processing if required
-                    feature=c_lyr.GetFeature(0)
+                if c_lyr.GetFeatureCount() > 1:
+                    print(
+                        "Warning: More than 1 feature in cleaning shapefile only first taken, dissolve data and use"
+                    )
+                try:  # Try to fix geom errors in cleaning data before reaging for processing if required
+                    feature = c_lyr.GetFeature(0)
                     geom = feature.GetGeometryRef()
                     if not geom.IsValid():
                         feature.SetGeometry(geom.Buffer(0))  # <====== SetGeometry
@@ -104,20 +120,27 @@ def clean_inference_shapes(clean_data_dir="./data/cln_data",
                 except:
                     print("unable to fix geometry")
                 try:
-                    c_feature=c_lyr.GetFeature(0)
+                    c_feature = c_lyr.GetFeature(0)
                 except:
                     print("Unable to get feature")
-                print("Cleaning Data Added:",fp,"\nFields in File",[field.name for field in c_lyr.schema])
+                print(
+                    "Cleaning Data Added:",
+                    fp,
+                    "\nFields in File",
+                    [field.name for field in c_lyr.schema],
+                )
                 try:
                     c_geometry = c_feature.geometry().Clone()
                 except:
                     print("unable to clone geom")
-                try: #Transfer cleaning data geo coordinates to the input file coordinate system
+                try:  # Transfer cleaning data geo coordinates to the input file coordinate system
                     clnSpatialRef = c_lyr.GetSpatialRef()
                     sr = osr.SpatialReference(str(clnSpatialRef))
                     srid = sr.GetAuthorityCode(None)
                     print("Cleaning SRID:", srid)
-                    coordTrans = osr.CoordinateTransformation(clnSpatialRef,inSpatialRef)
+                    coordTrans = osr.CoordinateTransformation(
+                        clnSpatialRef, inSpatialRef
+                    )
                     c_geometry.Transform(coordTrans)
                     print("Cleaning Data Geometry geo coordinate transformed")
                 except:
@@ -125,22 +148,25 @@ def clean_inference_shapes(clean_data_dir="./data/cln_data",
                 try:
                     all_geoms_union = all_geoms_union.Union(c_geometry).Clone()
                     print("Cleaining Geometry Unioined")
-                    print("All geom union geometry Area:",all_geoms_union.Area())
+                    print("All geom union geometry Area:", all_geoms_union.Area())
                 except:
                     print("Unable to union cleaning data geom")
 
-                try: # Fix if any geometry errors
+                try:  # Fix if any geometry errors
                     c_geometry.CloseRings()
-                    #print("Geometry Closed Rings")
+                    # print("Geometry Closed Rings")
                 except:
                     print("Unable Close Ring geom")
 
             # TIME taken for testing/Optimizing code can/should be commented
-            nd=time.time()
+            nd = time.time()
             print("****************************************************")
-            print("Wall Time for LOAD/UNION all cleaning data %5.4f min"%((nd-st)/60))
-            st=time.time()
-            all_union=all_geoms_union.Clone()
+            print(
+                "Wall Time for LOAD/UNION all cleaning data %5.4f min"
+                % ((nd - st) / 60)
+            )
+            st = time.time()
+            all_union = all_geoms_union.Clone()
             print("****************************************************")
             # </TIME>#######################################################
         except:
@@ -149,56 +175,71 @@ def clean_inference_shapes(clean_data_dir="./data/cln_data",
         print("Unable to READ/LOAD Cleaning Data main loop")
 
     # LOAD : AND INTERSECT the boundary aka feature envelope of the input files to reduce the processing if availble
-    if (all_union.Area()==0): print("All Clean Geom union geometry Area=0 nothing will be cleaned:")
-    print("input data boundry file path:",input_data_boundary_file_path)
-    if (os.path.isfile(input_data_boundary_file_path)):
-        dboundry = drv.Open(input_data_boundary_file_path,False)  #False as we are NOT editing the file
+    if all_union.Area() == 0:
+        print("All Clean Geom union geometry Area=0 nothing will be cleaned:")
+    print("input data boundry file path:", input_data_boundary_file_path)
+    if os.path.isfile(input_data_boundary_file_path):
+        dboundry = drv.Open(
+            input_data_boundary_file_path, False
+        )  # False as we are NOT editing the file
         dboundry_lyr = dboundry.GetLayer()
-        b_feature=dboundry_lyr.GetNextFeature()
-        b_geometry=b_feature.geometry().Clone()
-        all_union=all_union.Intersection(b_geometry).Clone()
+        b_feature = dboundry_lyr.GetNextFeature()
+        b_geometry = b_feature.geometry().Clone()
+        all_union = all_union.Intersection(b_geometry).Clone()
         print("Boundary Data Loaded from {}".format("sample2_out_boundry.shp"))
     else:
         print("No Boundary/Feature Envelope Data Loaded to reduce computing")
-    print("all geom union geometry Area:",all_union.Area())
-    if (all_union.Area()==0):
-        print("All Clean Geom union geometry Area=0 after boundry intersection nothing will be cleaned:")
-    #LOAD all Input files given for cleaning
+    print("all geom union geometry Area:", all_union.Area())
+    if all_union.Area() == 0:
+        print(
+            "All Clean Geom union geometry Area=0 after boundry intersection nothing will be cleaned:"
+        )
+    # LOAD all Input files given for cleaning
     input_data_fps = sorted(listdirpaths(input_data_dir))
-    print("input data directory",input_data_dir)
+    print("input data directory", input_data_dir)
     print("List of input data directories selected to PROCESS:CLEAN:")
-    print(*input_data_fps,sep="\n")
+    print(*input_data_fps, sep="\n")
     # FOR testing if you want to take only few files
-    if (all_union.Area()>0):
+    if all_union.Area() > 0:
         for fp in input_data_fps:
             # LOAD : READ each input file given
-            input_data_file = sorted(glob.glob(fp + "/*.shp") )
+            input_data_file = sorted(glob.glob(fp + "/*.shp"))
             print("File selected to PROCESS:CLEAN:", input_data_file[0])
-            ds = drv.Open(input_data_file[0],True)  # True as we are editing the file
+            ds = drv.Open(input_data_file[0], True)  # True as we are editing the file
             s_lyr = ds.GetLayer()
-            print("Total Features before Cleaning Filter {}".format(s_lyr.GetFeatureCount()))
-            print("input data file : fields",[field.name for field in s_lyr.schema])
-            st=time.time()
+            print(
+                "Total Features before Cleaning Filter {}".format(
+                    s_lyr.GetFeatureCount()
+                )
+            )
+            print("input data file : fields", [field.name for field in s_lyr.schema])
+            st = time.time()
             st_cpu = time.process_time()
 
-            for fid in range(s_lyr.GetFeatureCount()): # READ all features in the input file to check and remove
-                s_feature=s_lyr.GetFeature(fid)
+            for fid in range(
+                s_lyr.GetFeatureCount()
+            ):  # READ all features in the input file to check and remove
+                s_feature = s_lyr.GetFeature(fid)
 
                 # OPTION:1 Creating a point shape Using the centroid from the input file to check
                 # Instead of checking the polygon of the shape to reduce computing
                 shp_centroid = ogr.Geometry(ogr.wkbPoint)
-                shp_centroid.AddPoint(s_feature.GetField('CentroidX'),s_feature.GetField('CentroidY'))
+                shp_centroid.AddPoint(
+                    s_feature.GetField("CentroidX"), s_feature.GetField("CentroidY")
+                )
 
                 # OPTION:2 Using the polygon in the input feature to create a geometry
-                #s_geometry=s_feature.geometry().Clone()
-                #if (all_union.Intersection(s_geometry).IsEmpty()): #Using the polygon OPTION 2
+                # s_geometry=s_feature.geometry().Clone()
+                # if (all_union.Intersection(s_geometry).IsEmpty()): #Using the polygon OPTION 2
                 keep = True
-                try: # to see if intersection can  be done with errors in the cleaning shp file.
-                    keep = (all_union.Intersection(shp_centroid).IsEmpty()) # Using the centroid point of shape OPTION 1
-                    #if (all_union.Intersection(shp_centroid).IsEmpty()): # Using the centroid point of shape OPTION 1
-                except: # ignore that shape
+                try:  # to see if intersection can  be done with errors in the cleaning shp file.
+                    keep = all_union.Intersection(
+                        shp_centroid
+                    ).IsEmpty()  # Using the centroid point of shape OPTION 1
+                    # if (all_union.Intersection(shp_centroid).IsEmpty()): # Using the centroid point of shape OPTION 1
+                except:  # ignore that shape
                     pass
-                    print("Unable to intersect",fid)
+                    print("Unable to intersect", fid)
                 if keep:
                     pass
                     # if VERBOSE_granularity and (fid%VERBOSE_granularity == 0):
@@ -208,26 +249,33 @@ def clean_inference_shapes(clean_data_dir="./data/cln_data",
                     # if VERBOSE_granularity and (fid%VERBOSE_granularity == 0):
                     #     print("Deleted:",fid)
 
-            ds.ExecuteSQL('REPACK ' + s_lyr.GetName())
-            ds.ExecuteSQL('RECOMPUTE EXTENT ON ' + s_lyr.GetName())
-            #del ds   #not working need to check if required. Since when this goes out of scope it will be deleted
+            ds.ExecuteSQL("REPACK " + s_lyr.GetName())
+            ds.ExecuteSQL("RECOMPUTE EXTENT ON " + s_lyr.GetName())
+            # del ds   #not working need to check if required. Since when this goes out of scope it will be deleted
             print("Sample Features after deleting {}".format(s_lyr.GetFeatureCount()))
 
         # TIME taken for testing/Optimizing code can/should be commented
         nd = time.time()
         nd_cpu = time.process_time()
         print("*****************************************************")
-        print("Wall Time for check/remove %6.4f min"%((nd-st)/60))
-        print("CPU  Time for check/remove %6.4f min"%((nd_cpu-st_cpu)/60))
+        print("Wall Time for check/remove %6.4f min" % ((nd - st) / 60))
+        print("CPU  Time for check/remove %6.4f min" % ((nd_cpu - st_cpu) / 60))
         # </TIME>#######################################################
         print("*******************END - CLEANING *******************")
     else:
         print("No cleaining done : Cleaning artifacts are outside the input data area")
 
+
 ############################## To be customized to eval environment if required or testing ##########################
 # Not required since the clean function is called from the workflow
 def main():
-    from mpl_config import MPL_Config
-    clean_inference_shapes(MPL_Config.CLEAN_DATA_DIR,MPL_Config.FINAL_SHP_DIR,"./data/input_bound/sample3n4_out_bound.shp")
+    config = MPL_Config()
+    clean_inference_shapes(
+        config.CLEAN_DATA_DIR,
+        config.FINAL_SHP_DIR,
+        "./data/input_bound/sample3n4_out_bound.shp",
+    )
+
+
 if __name__ == "__main__":
     main()

--- a/mpl_config.py
+++ b/mpl_config.py
@@ -9,49 +9,65 @@ PI      : Chandi Witharana
 Author  : Rajitha Udwalpola
 """
 
+import os
+
 from config import Config
 
+
 class MPL_Config(object):
-    # ROOT_DIR where the code will look for all the input/output and generated files
-    # Can change this to the location where you want to run the code
-    ROOT_DIR = r'/usr/local/google/home/djfernandez/Desktop/MAPLE_v3'
+    """Initializes MPL_Config object.
 
-    ## Do not change this section
-    # Code depends on the relative locations indicated so should not change
-    # Code expects some of the locations to be available when executing.
-    #-----------------------------------------------------------------
-    INPUT_IMAGE_DIR = ROOT_DIR + r'/data/input_img_local'
-    DIVIDED_IMAGE_DIR = ROOT_DIR + r'/data/divided_img'
-    OUTPUT_SHP_DIR = ROOT_DIR + r'/data/output_shp'
-    FINAL_SHP_DIR = ROOT_DIR + r'/data/final_shp'
-    PROJECTED_SHP_DIR = ROOT_DIR + r'/data/projected_shp'
-    WATER_MASK_DIR = ROOT_DIR + r'/data/water_mask'
-    TEMP_W_IMG_DIR = ROOT_DIR + r'/data/water_mask/temp'
-    OUTPUT_IMAGE_DIR = ROOT_DIR + r'/data/output_img'
-    WORKER_ROOT =  ROOT_DIR + r'/data'
+    Arguments:
+    root_dir -- Path to where the workflow will be ran from.
+    weight_file -- Path to the Mask-RCNN model weights. Should be relative to the
+    root directory.
+    logging -- Whether to enable logging messages when running the workflow.
+    crop_size -- Used to determine tile size when splitting the image up.
+    num_spus_per_core -- Number of GPUs available per node.
+    """
 
-    # ADDED to include inference cleaning post-processing
-    CLEAN_DATA_DIR = ROOT_DIR + r'/data/cln_data'
-    INPUT_DATA_BOUNDARY_FILE_PATH = ROOT_DIR + r'/data/input_bound'
+    def __init__(
+        self,
+        root_dir="",
+        weight_file="hyp_best_train_weights_final.h5",
+        logging=True,
+        crop_size=200,
+        num_gpus_per_core=1,
+    ):
+        ## Do not change this section
+        # Code depends on the relative locations indicated so should not change
+        # Code expects some of the locations to be available when executing.
+        # -----------------------------------------------------------------
+        self.ROOT_DIR = root_dir if root_dir else os.getcwd()
+        self.INPUT_IMAGE_DIR = self.ROOT_DIR + r"/data/input_img_local"
+        self.DIVIDED_IMAGE_DIR = self.ROOT_DIR + r"/data/divided_img"
+        self.OUTPUT_SHP_DIR = self.ROOT_DIR + r"/data/output_shp"
+        self.FINAL_SHP_DIR = self.ROOT_DIR + r"/data/final_shp"
+        self.PROJECTED_SHP_DIR = self.ROOT_DIR + r"/data/projected_shp"
+        self.WATER_MASK_DIR = self.ROOT_DIR + r"/data/water_mask"
+        self.TEMP_W_IMG_DIR = self.ROOT_DIR + r"/data/water_mask/temp"
+        self.OUTPUT_IMAGE_DIR = self.ROOT_DIR + r"/data/output_img"
+        self.WORKER_ROOT = self.ROOT_DIR + r"/data"
 
-    #-------------------------------------------------------------------
-    # Name of the weight file used for the inference
-    weight_name = r'hyp_best_train_weights_final.h5'
+        # ADDED to include inference cleaning post-processing
+        self.CLEAN_DATA_DIR = self.ROOT_DIR + r"/data/cln_data"
+        self.INPUT_DATA_BOUNDARY_FILE_PATH = self.ROOT_DIR + r"/data/input_bound"
 
-    #-----------------------------------------------------------------
-    # Location of the weight file used for the inference
-    WEIGHT_PATH = ROOT_DIR + r"/" + weight_name
-    #-----------------------------------------------------------------
-    CROP_SIZE = 200
+        # -----------------------------------------------------------------
+        # Location of the weight file used for the inference
+        self.WEIGHT_PATH = self.ROOT_DIR + r"/" + weight_file
+        # -----------------------------------------------------------------
+        self.CROP_SIZE = crop_size
 
-    LOGGING = True
-    NUM_GPUS_PER_CORE = 1
+        self.LOGGING = logging
+        self.NUM_GPUS_PER_CORE = num_gpus_per_core
 
 
 class PolygonConfig(Config):
     """Configuration for training on the toy dataset.
     Derives from the base Config class and overrides some values.
     """
+
     # Give the configuration a recognizable name
     NAME = "ice_wedge_polygon"
 

--- a/mpl_divideimg_234_water_new.py
+++ b/mpl_divideimg_234_water_new.py
@@ -12,12 +12,17 @@ import h5py
 import numpy as np
 import os
 
-from mpl_config import  MPL_Config
+from mpl_config import MPL_Config
 from osgeo import gdal
 
-def divide_image(input_image_path,    # the image directory
-                 target_blocksize,    # the crop size
-                 file1, file2):       # cropped tile meta info, cropped file
+
+def divide_image(
+    config: MPL_Config,
+    input_image_path: str,  # the image directory
+    target_blocksize: int,  # the crop size
+    file1: str,
+    file2: str,
+):  # cropped tile meta info, cropped file
     """
     Script that breaks the image into smaller chunks (tiles)
     The script will zero out the water based on the water mask created for this input file
@@ -27,16 +32,16 @@ def divide_image(input_image_path,    # the image directory
     file1 : Keeps meta info on how to load file 2
     file2 : Cropped tiles
     """
-    worker_root = MPL_Config.WORKER_ROOT
-    water_dir = MPL_Config.WATER_MASK_DIR
+    worker_root = config.WORKER_ROOT
+    water_dir = config.WATER_MASK_DIR
 
-    #get the image name from path
-    new_file_name = (input_image_path.split('/')[-1])
+    # get the image name from path
+    new_file_name = input_image_path.split("/")[-1]
 
-    new_file_name = new_file_name.split('.')[0]
+    new_file_name = new_file_name.split(".")[0]
 
-    water_mask_dir = os.path.join(water_dir,new_file_name)
-    water_mask = os.path.join(water_mask_dir, "%s_watermask.tif"%new_file_name)
+    water_mask_dir = os.path.join(water_dir, new_file_name)
+    water_mask = os.path.join(water_mask_dir, "%s_watermask.tif" % new_file_name)
     MASK = gdal.Open(water_mask)
     mask_band = MASK.GetRasterBand(1)
     mask_arry = mask_band.ReadAsArray()
@@ -44,12 +49,12 @@ def divide_image(input_image_path,    # the image directory
     print(input_image_path)
     # convert the original image into the geo cordinates for further processing using gdal
     # https://gdal.org/tutorials/geotransforms_tut.html
-    #GT(0) x-coordinate of the upper-left corner of the upper-left pixel.
-    #GT(1) w-e pixel resolution / pixel width.
-    #GT(2) row rotation (typically zero).
-    #GT(3) y-coordinate of the upper-left corner of the upper-left pixel.
-    #GT(4) column rotation (typically zero).
-    #GT(5) n-s pixel resolution / pixel height (negative value for a north-up image).
+    # GT(0) x-coordinate of the upper-left corner of the upper-left pixel.
+    # GT(1) w-e pixel resolution / pixel width.
+    # GT(2) row rotation (typically zero).
+    # GT(3) y-coordinate of the upper-left corner of the upper-left pixel.
+    # GT(4) column rotation (typically zero).
+    # GT(5) n-s pixel resolution / pixel height (negative value for a north-up image).
 
     IMG1 = gdal.Open(input_image_path)
     gt1 = IMG1.GetGeoTransform()
@@ -86,7 +91,7 @@ def divide_image(input_image_path,    # the image directory
     transform = IMG1.GetGeoTransform()
 
     # ulx, uly is the upper left corner
-    ulx, x_resolution, _, uly, _, y_resolution  = transform
+    ulx, x_resolution, _, uly, _, y_resolution = transform
 
     # ---------------------- Divide image (tile) ----------------------
     overlap_rate = 0.2
@@ -96,15 +101,16 @@ def divide_image(input_image_path,    # the image directory
 
     image_count = 0
 
-    #Load the data frame
+    # Load the data frame
     from collections import defaultdict
+
     dict_ij = defaultdict(dict)
     dict_n = defaultdict(dict)
     tile_count = 0
 
-    y_list = range(0, ysize, int(block_size*(1-overlap_rate)))
-    x_list = range(0, xsize, int(block_size*(1-overlap_rate)))
-    dict_n['total'] = [len(y_list),len(x_list)]
+    y_list = range(0, ysize, int(block_size * (1 - overlap_rate)))
+    x_list = range(0, xsize, int(block_size * (1 - overlap_rate)))
+    dict_n["total"] = [len(y_list), len(x_list)]
 
     # ---------------------- Find each Upper left (x,y) for each divided images ----------------------
     #  ***-----------------
@@ -113,8 +119,7 @@ def divide_image(input_image_path,    # the image directory
     #  |
     #  |
     #
-    for id_i,i in enumerate(y_list):
-
+    for id_i, i in enumerate(y_list):
         # don't want moving window to be larger than row size of input raster
         if i + block_size < ysize:
             rows = block_size
@@ -123,25 +128,27 @@ def divide_image(input_image_path,    # the image directory
 
         # read col
         for id_j, j in enumerate(x_list):
-
             if j + block_size < xsize:
-                    cols = block_size
+                cols = block_size
             else:
                 cols = xsize - j
             # get block out of the whole raster
-            #todo check the array values is similar as ReadAsArray()
-            band_1_array = final_array_4[i:i+rows, j:j+cols]
-            band_2_array = final_array_2[i:i+rows, j:j+cols]
-            band_3_array = final_array_3[i:i+rows, j:j+cols]
+            # todo check the array values is similar as ReadAsArray()
+            band_1_array = final_array_4[i : i + rows, j : j + cols]
+            band_2_array = final_array_2[i : i + rows, j : j + cols]
+            band_3_array = final_array_3[i : i + rows, j : j + cols]
 
             # filter out black image
-            if band_3_array[0,0] == 0 and band_3_array[0,-1] == 0 and  \
-               band_3_array[-1,0] == 0 and band_3_array[-1,-1] == 0:
+            if (
+                band_3_array[0, 0] == 0
+                and band_3_array[0, -1] == 0
+                and band_3_array[-1, 0] == 0
+                and band_3_array[-1, -1] == 0
+            ):
                 continue
 
             dict_ij[id_i][id_j] = tile_count
             dict_n[tile_count] = [id_i, id_j]
-
 
             # stack three bands into one array
             img = np.stack((band_1_array, band_2_array, band_3_array), axis=2)
@@ -154,10 +161,12 @@ def divide_image(input_image_path,    # the image directory
             final_image = cv2.merge((out_B, out_G, out_R))
 
             # Upper left (x,y) for each images
-            ul_row_divided_img = uly + i*y_resolution
-            ul_col_divided_img = ulx + j*x_resolution
+            ul_row_divided_img = uly + i * y_resolution
+            ul_col_divided_img = ulx + j * x_resolution
 
-            data_c = np.array([i,j,ul_row_divided_img,ul_col_divided_img,tile_count])
+            data_c = np.array(
+                [i, j, ul_row_divided_img, ul_col_divided_img, tile_count]
+            )
             image_count += 1
             # Add tile into the data object data and the paremeters
             f1.create_dataset(f"image_{image_count}", data=final_image)
@@ -165,15 +174,16 @@ def divide_image(input_image_path,    # the image directory
             tile_count += 1
     # --------------- Store all the title as an object file
     values = np.array([x_resolution, y_resolution, image_count])
-    f2.create_dataset("values",data=values)
+    f2.create_dataset("values", data=values)
     import pickle
+
     db_file_path = os.path.join(worker_root, "neighbors/%s_ij_dict.pkl" % new_file_name)
-    dbfile = open(db_file_path, 'wb')
+    dbfile = open(db_file_path, "wb")
     pickle.dump(dict_ij, dbfile)
     dbfile.close()
 
     db_file_path = os.path.join(worker_root, "neighbors/%s_n_dict.pkl" % new_file_name)
-    dbfile = open(db_file_path, 'wb')
+    dbfile = open(db_file_path, "wb")
     pickle.dump(dict_n, dbfile)
     dbfile.close()
     f1.close()

--- a/mpl_infer_tiles_GPU_new.py
+++ b/mpl_infer_tiles_GPU_new.py
@@ -30,7 +30,6 @@ class Predictor(multiprocessing.Process):
         config: MPL_Config,
         input_queue: multiprocessing.JoinableQueue,
         process_counter: int,
-        POLYGON_DIR,
         output_shp_root: str,
         x_resolution: int,
         y_resolution: int,
@@ -48,7 +47,6 @@ class Predictor(multiprocessing.Process):
         self.device = "/gpu:%d" % self.process_counter if self.use_gpu else "/cpu:0"
         self.len_imgs = len_imgs
 
-        self.POLYGON_DIR = POLYGON_DIR
         self.output_shp_root = output_shp_root
 
         self.x_resolution = x_resolution
@@ -174,7 +172,6 @@ class Predictor(multiprocessing.Process):
 
 def inference_image(
     config: MPL_Config,
-    POLYGON_DIR: str,
     output_shp_root: str,
     file1: str,
     file2: str,
@@ -200,7 +197,6 @@ def inference_image(
         config,
         input_queue,
         0,
-        POLYGON_DIR,
         output_shp_root,
         x_resolution,
         y_resolution,
@@ -215,7 +211,6 @@ def inference_image(
             config,
             input_queue,
             i,
-            POLYGON_DIR,
             output_shp_root,
             x_resolution,
             y_resolution,

--- a/mpl_infer_tiles_GPU_new.py
+++ b/mpl_infer_tiles_GPU_new.py
@@ -10,9 +10,11 @@ Author  : Rajitha Udwalpola
 """
 
 import h5py
+import model as modellib
 import multiprocessing
 import numpy as np
 import os
+import pickle
 import sys
 import shapefile
 import tensorflow as tf
@@ -21,17 +23,28 @@ from collections import defaultdict
 from mpl_config import MPL_Config, PolygonConfig
 from skimage.measure import find_contours
 
-class Predictor(multiprocessing.Process):
-    def __init__(self, input_queue, gpu_id,
-                          POLYGON_DIR,
-                          weights_path,
-                          output_shp_root,
-                          x_resolution,
-                          y_resolution,len_imgs,image_name):
 
+class Predictor(multiprocessing.Process):
+    def __init__(
+        self,
+        config: MPL_Config,
+        input_queue: multiprocessing.JoinableQueue,
+        use_gpu: bool,
+        process_counter: int,
+        POLYGON_DIR,
+        weights_path: str,
+        output_shp_root: str,
+        x_resolution: int,
+        y_resolution: int,
+        len_imgs: int,
+        image_name: str,
+    ):
         multiprocessing.Process.__init__(self)
+        self.config = config
         self.input_queue = input_queue
-        self.gpu_id = gpu_id
+        self.process_counter = process_counter
+        self.use_gpu = use_gpu
+        self.device = "/gpu:%d" % self.process_counter if self.use_gpu else "/cpu:0"
         self.len_imgs = len_imgs
 
         self.POLYGON_DIR = POLYGON_DIR
@@ -43,11 +56,10 @@ class Predictor(multiprocessing.Process):
         self.image_name = image_name
 
     def run(self):
-
         # --------------------------- Preseting ---------------------------
         # Root directory of the project
-        ROOT_DIR = MPL_Config.ROOT_DIR
-        MY_WEIGHT_FILE = MPL_Config.WEIGHT_PATH
+        ROOT_DIR = self.config.ROOT_DIR
+        MY_WEIGHT_FILE = self.config.WEIGHT_PATH
 
         # Import Mask RCNN
         sys.path.append(ROOT_DIR)
@@ -55,12 +67,9 @@ class Predictor(multiprocessing.Process):
         # Directory to save logs and trained model
         MODEL_DIR = os.path.join(ROOT_DIR, "local_dir/datasets/logs")
 
-
-        import model as modellib
-
         # --------------------------- Configurations ---------------------------
         # Set config
-        config = PolygonConfig()
+        model_config = PolygonConfig()
 
         output_shp_root = self.output_shp_root
 
@@ -69,146 +78,177 @@ class Predictor(multiprocessing.Process):
         # Useful if you're training a model on the same
         # machine, in which case use CPU and leave the
         # GPU for training.
-        DEVICE = "/gpu:%s"%(self.gpu_id)  # /cpu:0 or /gpu:0
-        os.environ['CUDA_VISIBLE_DEVICES'] = "{}".format(self.gpu_id)
+        if self.use_gpu:
+            os.environ["CUDA_VISIBLE_DEVICES"] = "{}".format(self.process_counter)
 
         # Inspect the model in training or inference modes
         # values: 'inference' or 'training'
         # TODO: code for 'training' test mode not ready yet
         # Create model in inference mode
-        with tf.device(DEVICE):
-            model = modellib.MaskRCNN(mode="inference", model_dir=MODEL_DIR,
-                                      config=config)
+        with tf.device(self.device):
+            model = modellib.MaskRCNN(
+                mode="inference", model_dir=MODEL_DIR, config=model_config
+            )
 
         # Load weights
         print("Loading weights ", MODEL_DIR)
         model.load_weights(MY_WEIGHT_FILE, by_name=True)
-        output_shp_name_1 = output_shp_root.split('/')[-1]
+        output_shp_name_1 = output_shp_root.split("/")[-1]
 
-        temp_name = "%s_%d.shp"%(output_shp_name_1, self.gpu_id)
+        temp_name = "%s_%d.shp" % (output_shp_name_1, self.process_counter)
 
         output_path_1 = os.path.join(output_shp_root, temp_name)
         w_final = shapefile.Writer(output_path_1)
-        w_final.field('Class', 'C', size=5)
-        count =0
+        w_final.field("Class", "C", size=5)
+        count = 0
         total = self.len_imgs
         # --------------------------- Workers ---------------------------
 
         dict_polygons = defaultdict(dict)
-        while True:
+        while not self.input_queue.empty():
             job_data = self.input_queue.get()
             count += 1
 
-            if job_data is None:
-                self.input_queue.task_done()
-                print("Exiting Process %d" % self.gpu_id)
-                break
+            # get the upper left x y of the image
+            ul_row_divided_img = job_data[0][2]
+            ul_col_divided_img = job_data[0][3]
+            tile_no = job_data[0][4]
+            image = job_data[1]
 
-            else:
-                # get the upper left x y of the image
-                ul_row_divided_img = job_data[0][2]
-                ul_col_divided_img = job_data[0][3]
-                tile_no = job_data[0][4]
-                image = job_data[1]
+            results = model.detect([image], verbose=False)
 
-                results = model.detect([image], verbose=False)
+            r = results[0]
 
-                r = results[0]
+            if len(r["class_ids"]):
+                count_p = 0
 
-                if len(r['class_ids']):
-                    count_p = 0
+                for id_masks in range(r["masks"].shape[2]):
+                    # read the mask
+                    mask = r["masks"][:, :, id_masks]
+                    padded_mask = np.zeros(
+                        (mask.shape[0] + 2, mask.shape[1] + 2), dtype=np.uint8
+                    )
+                    padded_mask[1:-1, 1:-1] = mask
+                    class_id = r["class_ids"][id_masks]
 
-                    for id_masks in range(r['masks'].shape[2]):
+                    try:
+                        contours = find_contours(padded_mask, 0.5, "high")[
+                            0
+                        ] * np.array([[self.y_resolution, self.x_resolution]])
+                        contours = contours + np.array(
+                            [[float(ul_row_divided_img), float(ul_col_divided_img)]]
+                        )
+                        # swap two cols
+                        contours.T[[0, 1]] = contours.T[[1, 0]]
+                        # write shp file
+                        w_final.poly([contours.tolist()])
+                        w_final.record(Class=class_id)
 
-                        # read the mask
-                        mask = r['masks'][:, :, id_masks]
-                        padded_mask = np.zeros(
-                            (mask.shape[0] + 2, mask.shape[1] + 2), dtype=np.uint8)
-                        padded_mask[1:-1, 1:-1] = mask
-                        class_id = r['class_ids'][id_masks]
+                    except:
+                        contours = []
+                        pass
 
-                        try:
-                            contours = find_contours(padded_mask, 0.5, 'high')[0] * np.array(
-                                [[self.y_resolution, self.x_resolution]])
-                            contours = contours + np.array([[float(ul_row_divided_img), float(ul_col_divided_img)]])
-                            # swap two cols
-                            contours.T[[0, 1]] = contours.T[[1, 0]]
-                            # write shp file
-                            w_final.poly([contours.tolist()])
-                            w_final.record(Class=class_id)
+                    count_p += 1
 
-                        except:
-                            contours = []
-                            pass
+            dict_polygons[int(tile_no)] = [r["masks"].shape[2]]
 
-                        count_p += 1
+            if self.config.LOGGING:
+                print(
+                    f"## {count} of {total} ::: {len(r['class_ids'])}  $$$$ {r['class_ids']}"
+                )
+                sys.stdout.flush()
 
-
-                dict_polygons[int(tile_no)] = [r['masks'].shape[2]]
-
-                if (MPL_Config.LOGGING):
-                    print(f"## {count} of {total} ::: {len(r['class_ids'])}  $$$$ {r['class_ids']}")
-                    sys.stdout.flush()
-
-        import pickle
-        worker_root = MPL_Config.WORKER_ROOT
-        db_file_path = os.path.join(worker_root, "neighbors/%s_polydict_%d.pkl" % (self.image_name,self.gpu_id))
-        dbfile = open(db_file_path, 'wb')
+        worker_root = self.config.WORKER_ROOT
+        db_file_path = os.path.join(
+            worker_root, "neighbors/%s_polydict_%d.pkl" % (self.image_name, self.process_counter)
+        )
+        dbfile = open(db_file_path, "wb")
         pickle.dump(dict_polygons, dbfile)
         dbfile.close()
         w_final.close()
+        self.input_queue.task_done()
+        print("Exiting Process %d" % self.process_counter)
 
-def inference_image(POLYGON_DIR,
-                    weights_path,
-                    output_shp_root,
-                    file1,file2,image_name):
 
-    f1 = h5py.File(file1, 'r')
-    f2 = h5py.File(file2, 'r')
+def inference_image(
+    config: MPL_Config,
+    POLYGON_DIR: str,
+    weights_path: str,
+    output_shp_root: str,
+    file1: str,
+    file2: str,
+    image_name: str,
+):
+    f1 = h5py.File(file1, "r")
+    f2 = h5py.File(file2, "r")
 
-    values = f2.get('values')
+    values = f2.get("values")
     n1 = np.array(values)
     x_resolution = n1[0]
     y_resolution = n1[1]
     len_imgs = n1[2]
 
     # The number of GPU you want to use
-    num_gpus = MPL_Config.NUM_GPUS_PER_CORE
+    num_gpus = config.NUM_GPUS_PER_CORE
 
     input_queue = multiprocessing.JoinableQueue()
 
     p_list = []
 
-    for i in range(0, num_gpus):
-        # set the i as the GPU device you want to use
-
-        p = Predictor(input_queue, i,
-                      POLYGON_DIR,
-                      weights_path,
-                      output_shp_root,
-                      x_resolution,
-                      y_resolution,
-                      len_imgs,image_name)
+    # If the number of GPUs pero core is 0 create a single predictor that will
+    # run on the CPU.
+    if config.NUM_GPUS_PER_CORE == 0:
+        p = Predictor(
+            config,
+            input_queue,
+            False,
+            0,
+            POLYGON_DIR,
+            weights_path,
+            output_shp_root,
+            x_resolution,
+            y_resolution,
+            len_imgs,
+            image_name,
+        )
         p_list.append(p)
+    else:
+        # If there are GPUs available, create a Predictor for each one to run
+        # multiple inferences in parallel.
+        for i in range(num_gpus):
+            # set the i as the GPU device you want to use
+            p = Predictor(
+                config,
+                input_queue,
+                True,
+                i,
+                POLYGON_DIR,
+                weights_path,
+                output_shp_root,
+                x_resolution,
+                y_resolution,
+                len_imgs,
+                image_name,
+            )
+            p_list.append(p)
 
-    for p in p_list:
-        p.start()
-
-
+    # populate input queue with tasks for processes to consume.
     for img in range(int(len_imgs)):
         image = f1.get(f"image_{img+1}")
         params = f2.get(f"param_{img+1}")
         img_stack = np.array(image)
-        img_data = (np.array(params))
+        img_data = np.array(params)
 
-        job = [img_data,img_stack]
+        job = [img_data, img_stack]
 
         input_queue.put(job)
     f1.close()
     f2.close()
 
-    for i in range(num_gpus):
-        input_queue.put(None)
+    # start processes to start consuming jobs from the queue.
+    for p in p_list:
+        p.start()
 
+    # join all processes to ensure proper clean up when all jobs are done.
     for p in p_list:
         p.join()

--- a/mpl_infer_tiles_GPU_new.py
+++ b/mpl_infer_tiles_GPU_new.py
@@ -105,6 +105,7 @@ class Predictor(multiprocessing.Process):
         # --------------------------- Workers ---------------------------
 
         dict_polygons = defaultdict(dict)
+        # keep pulling jobs from the input queue until it's empty.
         while not self.input_queue.empty():
             job_data = self.input_queue.get()
             count += 1
@@ -160,7 +161,8 @@ class Predictor(multiprocessing.Process):
 
         worker_root = self.config.WORKER_ROOT
         db_file_path = os.path.join(
-            worker_root, "neighbors/%s_polydict_%d.pkl" % (self.image_name, self.process_counter)
+            worker_root,
+            "neighbors/%s_polydict_%d.pkl" % (self.image_name, self.process_counter),
         )
         dbfile = open(db_file_path, "wb")
         pickle.dump(dict_polygons, dbfile)

--- a/mpl_process_shapefile.py
+++ b/mpl_process_shapefile.py
@@ -46,15 +46,16 @@ def get_coordinate_system_info(filepath):
         print(f"Error: {e}")
         return None
 
+
 def write_prj_file(geotiff_path, prj_file_path):
     """
-        Will create the prj file by getting the geo cordinate system from the input tiff file
+    Will create the prj file by getting the geo cordinate system from the input tiff file
 
-        Parameters
-        ----------
-        geotiff_path : Path to the geo tiff used for processing
-        prj_file_path : Path to the location to create the prj files
-        """
+    Parameters
+    ----------
+    geotiff_path : Path to the geo tiff used for processing
+    prj_file_path : Path to the location to create the prj files
+    """
     try:
         # Get the coordinate system information
         wkt = get_coordinate_system_info(geotiff_path)
@@ -62,7 +63,7 @@ def write_prj_file(geotiff_path, prj_file_path):
         print(wkt)
         if wkt is not None:
             # Write the WKT to a .prj file
-            with open(prj_file_path, 'w') as prj_file:
+            with open(prj_file_path, "w") as prj_file:
                 prj_file.write(wkt)
 
             print(f"Coordinate system information written to {prj_file_path}")
@@ -71,6 +72,7 @@ def write_prj_file(geotiff_path, prj_file_path):
 
     except Exception as e:
         print(f"Error: {e}")
+
 
 def copy_to_project_dir(source_path, new_name):
     try:
@@ -88,19 +90,22 @@ def copy_to_project_dir(source_path, new_name):
         # Copy the source directory to the same location and rename it
         shutil.copytree(source_path, new_directory_path)
 
-        print(f"Directory copied to '{new_directory_path}' and renamed to '{new_name}'.")
+        print(
+            f"Directory copied to '{new_directory_path}' and renamed to '{new_name}'."
+        )
 
     except Exception as e:
         print(f"Error: {e}")
 
-def process_shapefile(image_name):
-    data_dir = MPL_Config.WORKER_ROOT
-    image_file_name = (image_name).split('.tif')[0]
 
-    shp_dir = os.path.join(data_dir, 'final_shp', image_file_name)
-    #projected_dir = os.path.join(data_dir, 'projected_shp', image_file_name)
-    projected_dir=os.path.join(MPL_Config.PROJECTED_SHP_DIR,image_file_name)
-    temp_dir = os.path.join(data_dir, 'temp_shp', image_file_name)
+def process_shapefile(config: MPL_Config, image_name: str):
+    data_dir = config.WORKER_ROOT
+    image_file_name = (image_name).split(".tif")[0]
+
+    shp_dir = os.path.join(data_dir, "final_shp", image_file_name)
+    # projected_dir = os.path.join(data_dir, 'projected_shp', image_file_name)
+    projected_dir = os.path.join(config.PROJECTED_SHP_DIR, image_file_name)
+    temp_dir = os.path.join(data_dir, "temp_shp", image_file_name)
 
     shape_file = os.path.join(shp_dir, f"{image_file_name}.shp")
     output_shape_file = os.path.join(temp_dir, f"{image_file_name}.shp")
@@ -152,12 +157,14 @@ def process_shapefile(image_name):
 
     for shaperec in r.iterShapeRecords():
         rec = shaperec.record
-        rec.extend([
-            image_file_name[0:4],
-            image_file_name[5:13],
-            image_file_name[13:19],
-            image_file_name[20:36]
-        ])
+        rec.extend(
+            [
+                image_file_name[0:4],
+                image_file_name[5:13],
+                image_file_name[13:19],
+                image_file_name[20:36],
+            ]
+        )
 
         poly_vtx = shaperec.shape.points
         poly = Polygon(poly_vtx)
@@ -187,15 +194,17 @@ def process_shapefile(image_name):
     os.chmod(temp_dir, 0o777)
 
     temp_dir_prj = os.path.join(temp_dir, f"{image_file_name}.prj")
-    input_image = os.path.join(MPL_Config.INPUT_IMAGE_DIR, image_name)
+    input_image = os.path.join(config.INPUT_IMAGE_DIR, image_name)
     write_prj_file(input_image, temp_dir_prj)
 
     try:
-        shutil.copytree(temp_dir,projected_dir)
+        shutil.copytree(temp_dir, projected_dir)
     except Exception as e:
         print(f"Error creating projected directory {projected_dir}: {e}")
 
+
 # Example usage:
+
 
 def get_tif_file_names(directory_path):
     tif_file_names = []
@@ -205,13 +214,14 @@ def get_tif_file_names(directory_path):
 
         # Add each *.tif file name to the list
         for file in files:
-            if file.endswith('.tif'):
+            if file.endswith(".tif"):
                 tif_file_names.append(file)
 
     except Exception as e:
         print(f"Error: {e}")
 
     return tif_file_names
+
 
 # Unit TEST CODE
 #

--- a/mpl_stitchshpfile_new.py
+++ b/mpl_stitchshpfile_new.py
@@ -7,43 +7,47 @@ PI      : Chandi Witharana
 Author  : Rajitha Udwalpola
 """
 
+import glob
 import numpy as np
 import os
+import pickle
 import random
 import shapefile
 
+from collections import defaultdict
+from mpl_config import MPL_Config
 from osgeo import ogr
 from scipy.spatial import distance
 from shapely.geometry import Polygon
 
-def stitch_shapefile(input_root,output_root,output_file,image_name):
+
+def stitch_shapefile(
+    config: MPL_Config,
+    input_root: str,
+    output_root: str,
+    output_file: str,
+    image_name: str,
+):
     # create a output shapefile
     output_path_1 = os.path.join(output_root, "%s.shp" % output_file)
     print(output_path_1)
     w = shapefile.Writer(output_path_1)
 
-    import glob
-    file_path_shp = os.path.join(input_root,"*.shp")
+    file_path_shp = os.path.join(input_root, "*.shp")
     files = sorted(glob.glob(file_path_shp))
     for file in files:
         print(file)
         r = shapefile.Reader(file)
         w.fields = r.fields[1:]  # skip first deletion field
         for shaperec in r.iterShapeRecords():
-             w.record(*shaperec.record)
-             w.shape(shaperec.shape)
+            w.record(*shaperec.record)
+            w.shape(shaperec.shape)
     w.close()
-
-
-    import glob
-    import pickle
-    from collections import defaultdict
 
     polygon_dict = defaultdict(dict)
 
     ### UPDATED CODE - amal 01/05/2023
-    from mpl_config import MPL_Config
-    worker_root = MPL_Config.WORKER_ROOT
+    worker_root = config.WORKER_ROOT
     # Path to the location where the multiple GPUs wrote the inferences from the ML
     file_path = os.path.join(worker_root, "neighbors/%s_polydict_*.pkl" % (image_name))
     # ORIGINAL CODE
@@ -54,25 +58,22 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
     files = sorted(glob.glob(file_path))
     poly_count = 0
     for file in files:
-        dbfile = open(file, 'rb')
+        dbfile = open(file, "rb")
         temp_dict = pickle.load(dbfile)
-        for k,v in temp_dict.items():
-
-            polygon_dict[k] = [poly_count,poly_count+v[0]]
+        for k, v in temp_dict.items():
+            polygon_dict[k] = [poly_count, poly_count + v[0]]
             poly_count += v[0]
 
-    # Commented this out as it is imported earlier from due to a fix -amal
-    # from mpl_config import MPL_Config
-    worker_root = MPL_Config.WORKER_ROOT
+    worker_root = config.WORKER_ROOT
     dict_ij_path = os.path.join(worker_root, "neighbors/%s_ij_dict.pkl" % image_name)
-    dbfile = open(dict_ij_path, 'rb')
+    dbfile = open(dict_ij_path, "rb")
     dict_ij = pickle.load(dbfile)
     dbfile.close()
 
     dict_n_path = os.path.join(worker_root, "neighbors/%s_n_dict.pkl" % image_name)
-    dbfile = open(dict_n_path, 'rb')
+    dbfile = open(dict_n_path, "rb")
     dict_n = pickle.load(dbfile)
-    size_i, size_j = dict_n['total']
+    size_i, size_j = dict_n["total"]
     dbfile.close()
 
     # read the shape file with recording the index
@@ -88,13 +89,12 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
         ref_polygon = Polygon(current_plyn_vtices)
         # parse wkt return
         geom = ogr.CreateGeometryFromWkt(ref_polygon.centroid.wkt)
-        centroid_x, centroid_y = geom.GetPoint(0)[0],geom.GetPoint(0)[1]
+        centroid_x, centroid_y = geom.GetPoint(0)[0], geom.GetPoint(0)[1]
         centroid_list.append([centroid_x, centroid_y])
 
     close_list = list()
-    print ("Total number of polygons: ", len(centroid_list))
+    print("Total number of polygons: ", len(centroid_list))
     tile_blocksize = 4
-
 
     for id_i in range(0, size_i, 3):
         if id_i + tile_blocksize < size_i:
@@ -114,23 +114,31 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
 
             for ii in range(n_i):
                 for jj in range(n_j):
-                    if (ii+id_i) in dict_ij.keys():
-                        if (jj+id_j) in dict_ij[(ii+id_i)].keys():
-                           n = dict_ij[ii+id_i][jj+id_j]
-                           poly_range = polygon_dict[n]
-                           poly_list = [*range(poly_range[0],poly_range[1])]
-                           poly_neighbors.extend(poly_list)
-                           centroid_neighbors.extend(centroid_list[poly_range[0]:poly_range[1]])
+                    if (ii + id_i) in dict_ij.keys():
+                        if (jj + id_j) in dict_ij[(ii + id_i)].keys():
+                            n = dict_ij[ii + id_i][jj + id_j]
+                            poly_range = polygon_dict[n]
+                            poly_list = [*range(poly_range[0], poly_range[1])]
+                            poly_neighbors.extend(poly_list)
+                            centroid_neighbors.extend(
+                                centroid_list[poly_range[0] : poly_range[1]]
+                            )
 
-            if(len(centroid_neighbors) == 0):
+            if len(centroid_neighbors) == 0:
                 continue
-            dst_array = distance.cdist(centroid_neighbors, centroid_neighbors, 'euclidean')
+            dst_array = distance.cdist(
+                centroid_neighbors, centroid_neighbors, "euclidean"
+            )
 
             # filter out close objects
             filter_object_array = np.argwhere((dst_array < 10) & (dst_array > 0))
 
-            filter_object_array[:, 0] = [poly_neighbors[i] for i in filter_object_array[:, 0] ]
-            filter_object_array[:, 1] =  [poly_neighbors[i] for i in filter_object_array[:, 1] ]
+            filter_object_array[:, 0] = [
+                poly_neighbors[i] for i in filter_object_array[:, 0]
+            ]
+            filter_object_array[:, 1] = [
+                poly_neighbors[i] for i in filter_object_array[:, 1]
+            ]
 
             if filter_object_array.shape[0] != 0:
                 for i in filter_object_array:
@@ -138,10 +146,8 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
             else:
                 continue
 
-
-
     # remove duplicated index
-    close_list =  set(frozenset(sublist) for sublist in close_list)
+    close_list = set(frozenset(sublist) for sublist in close_list)
     close_list = [list(x) for x in close_list]
 
     # --------------- looking for connected components in a graph ---------------
@@ -151,6 +157,7 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
         for each in lists:
             for item in each:
                 neighbors[item].update(each)
+
         def component(node, neighbors=neighbors, seen=seen, see=seen.add):
             nodes = set([node])
             next_node = nodes.pop
@@ -159,6 +166,7 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
                 see(node)
                 nodes |= neighbors[node] - seen
                 yield node
+
         for node in neighbors:
             if node not in seen:
                 yield sorted(component(node))
@@ -189,7 +197,7 @@ def stitch_shapefile(input_root,output_root,output_file,image_name):
     # Repack and recompute extent
     # This is not mandatory but it organizes the FID's (so they start at 0 again and not 1)
     # and recalculates the spatial extent.
-    ds.ExecuteSQL('REPACK ' + lyr.GetName())
-    ds.ExecuteSQL('RECOMPUTE EXTENT ON ' + lyr.GetName())
+    ds.ExecuteSQL("REPACK " + lyr.GetName())
+    ds.ExecuteSQL("RECOMPUTE EXTENT ON " + lyr.GetName())
 
     print("Features after: {}".format(lyr.GetFeatureCount()))

--- a/mpl_workflow_create_dir_struct.py
+++ b/mpl_workflow_create_dir_struct.py
@@ -77,7 +77,7 @@ def unit_test():
     create_dir_path("./data4/final_shp/test_image_01/")
 
 
-def create_maple_dir_structure():
+def create_maple_dir_structure(config: MPL_Config):
     # Created dir structure that is required for the maple workflow
     # data/
     # ├── cln_data
@@ -90,17 +90,18 @@ def create_maple_dir_structure():
     # ├── projected_shp
     # └── water_mask
     #     └── temp
+    config = MPL_Config()
 
-    create_dir_path(MPL_Config.INPUT_IMAGE_DIR)
-    create_dir_path(MPL_Config.DIVIDED_IMAGE_DIR)
-    create_dir_path(MPL_Config.OUTPUT_SHP_DIR)
-    create_dir_path(MPL_Config.FINAL_SHP_DIR)
-    create_dir_path(MPL_Config.WATER_MASK_DIR)
-    create_dir_path(MPL_Config.TEMP_W_IMG_DIR)
-    create_dir_path(MPL_Config.OUTPUT_IMAGE_DIR)
-    create_dir_path(os.path.join(MPL_Config.WORKER_ROOT, "neighbors/"))
-    create_dir_path(os.path.join(MPL_Config.WORKER_ROOT, "projected_shp/"))
-    create_dir_path(MPL_Config.CLEAN_DATA_DIR)
+    create_dir_path(config.INPUT_IMAGE_DIR)
+    create_dir_path(config.DIVIDED_IMAGE_DIR)
+    create_dir_path(config.OUTPUT_SHP_DIR)
+    create_dir_path(config.FINAL_SHP_DIR)
+    create_dir_path(config.WATER_MASK_DIR)
+    create_dir_path(config.TEMP_W_IMG_DIR)
+    create_dir_path(config.OUTPUT_IMAGE_DIR)
+    create_dir_path(os.path.join(config.WORKER_ROOT, "neighbors/"))
+    create_dir_path(os.path.join(config.WORKER_ROOT, "projected_shp/"))
+    create_dir_path(config.CLEAN_DATA_DIR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- This is in contrast of the current approach which relies on updating hardcoded string paths inside of mpl_config.py. 
- Most of the changes comprise updating function calls and constructors to take in a config object which is then used to reference the relevant attributes of the class instead of accessing stacking variables from the config.
- Please pay extra attention to the changes in mpl_infer_tiles_GPU_new.py
    - The predictor constructor was updated to support creating predictors that run on either a CPU or a GPU
    - behavior of how the predictor run method pulls jobs from the input queue was updated to remove infinite "while true" loop and base it on the input_queue being empty. This means that the order of operations in inference_image had to be changed so that the jobs are added to the queue BEFORE the processes are started. 
- There are a lot of misc changes due to running the Black formatter on the files that updated