### PR TITLE
create Path to /neighbors before trying to open file

### DIFF
--- a/mpl_divideimg_234_water_new.py
+++ b/mpl_divideimg_234_water_new.py
@@ -11,6 +11,7 @@ import cv2
 import h5py
 import numpy as np
 import os
+from pathlib import Path
 
 from mpl_config import MPL_Config
 from osgeo import gdal
@@ -176,6 +177,9 @@ def divide_image(
     values = np.array([x_resolution, y_resolution, image_count])
     f2.create_dataset("values", data=values)
     import pickle
+
+    path_to_neighbors = os.path.join(worker_root, "neighbors")
+    Path(path_to_neighbors).mkdir(parents=True, exist_ok=True)
 
     db_file_path = os.path.join(worker_root, "neighbors/%s_ij_dict.pkl" % new_file_name)
     dbfile = open(db_file_path, "wb")


### PR DESCRIPTION
This fixes an error in the maple_divideimage_234_new.py that is called by maple workflow.

The script tries to open a file that is in a directory that does not yet exist. I added a step to create that directory first. 