### PR TITLE
There shouldn't be a config argument for create_maple_dir_structure

### DIFF
--- a/mpl_workflow_create_dir_struct.py
+++ b/mpl_workflow_create_dir_struct.py
@@ -77,7 +77,7 @@ def unit_test():
     create_dir_path("./data4/final_shp/test_image_01/")
 
 
-def create_maple_dir_structure(config: MPL_Config):
+def create_maple_dir_structure():
     # Created dir structure that is required for the maple workflow
     # data/
     # ├── cln_data


### PR DESCRIPTION
`create_maple_dir_structure` shouldn't require any arguments since it isn't called with any arguments 